### PR TITLE
Fix selected header rendering artifact

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
 
 
 <section class="section section-dark section-chevron_alt section-first"
-    id="main" tabindex="-1">
+    id="main">
   <div class="usa-grid section-bg-parent">
     <div class="usa-width-whole billboard  section-bg">
       <h1 class="billboard-display_text">The Government Innovation Platform</h1>


### PR DESCRIPTION
The issue is that a rendering artifact--a blue or grey non-rectangular outline that cuts through the navigation links--shows up in Chrome when clicking anywhere in the first `<section>` of the home page.  (See github issue 18F/cg-landing#67 for a screenshot.)

The cause is that Chrome interprets a `tabindex` attribute on the first `<section>` to mean the element is selectable and should be outlined on click.  The irregularity of the outline (i.e. non-rectangular, half of it extending beyond the element's content box into the header nav) is due to the `::before` psuedo-element which, itself, extends outside the element to offset its background image.

The fix is to simply remove `tabindex` from the first `<section>`.

(See 18F/cg-landing#77 for further discussion.)